### PR TITLE
Made a more visual presentation of HKDF length param prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,11 @@ These are the standard things you should watch out for. Hopefully you've already
    This means that a single ciphertext can be decrypted (using different keys) to different *valid* plaintexts.
    This is true even for AEAD ciphers such as AES-GCM and chacha20/poly1305.
    AES-GCM not being committing [broke some security properties of Facebook  Messenger](https://eprint.iacr.org/2019/016).
- *  [Key Derivation Functions](https://en.wikipedia.org/wiki/Key_derivation_function) (KDFs) may not generate different outputs when only the length is varied. 
-    ([HKDF](https://en.wikipedia.org/wiki/HKDF), my favorite KDF, is an example of this.) Most KDFs take in both an Initial Keying Material (`IKM`) an a per-derived-key `Info` value and `Length`. (They may take in other parameters but these can be ignored safely for this gotcha.) If all inputs _except_ the `Length` are kept constant, the outputs may be related. For example: `HKDF(IKM=0x0102030405060708, Info="Example Key", Length=16) = Prefix16(HKDF(IKM=0x0102030405060708, Info="Example Key", Length=32)`
+ *  [Key Derivation Functions](https://en.wikipedia.org/wiki/Key_derivation_function) (KDFs) may not generate different outputs when only the length is varied.
+    ([HKDF](https://en.wikipedia.org/wiki/HKDF), my favorite KDF, is an example of this.) Most KDFs take in both an Initial Keying Material (`IKM`) an a per-derived-key `Info` value and `Length`. (They may take in other parameters but these can be ignored safely for this gotcha.) If all inputs _except_ the `Length` are kept constant, the outputs may be related. For example, here are the outputs of `HKDF(IKM=0x0102030405060708, Salt="mysalt", Info="myinfo", Length=X)` for `Length=16` and then `Length=32`:
+
+        0x6adb5cbd648b0af649d1f507543df984
+        0x6adb5cbd648b0af649d1f507543df98484ed986c43cfcec47056b1d49795d944
 
 ## Nonces/IVs
 [Nonce](https://en.wikipedia.org/wiki/Cryptographic_nonce) (or [Initialization Vector (IV)](https://en.wikipedia.org/wiki/Initialization_vector)) are two different names for essentially the same thing.


### PR DESCRIPTION
Here's the Rust code I used to generate the data:

```rust
fn main() {
    let salt = b"mysalt";
    let info = b"myinfo";
    let ikm = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
    let h = hkdf::Hkdf::<sha2::Sha256>::new(Some(salt), &ikm);

    let mut buf1 = [0u8; 16];
    h.expand(info, &mut buf1).unwrap();
    println!("buf1 == {:02x?}", buf1);

    let mut buf2 = [0u8; 32];
    h.expand(info, &mut buf2).unwrap();
    println!("buf2 == {:02x?}", buf2);
}
```
dependencies:
```
digest = "0.9"
sha2 = "0.9"
```